### PR TITLE
Fix #241 add after_entry_update_hooks to Reader

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,12 @@ Version 1.20
 
 Unreleased
 
+* Added public property :attr:`~Reader.after_entry_update_hooks` to
+  :class:`Reader`, which contains list of hooks to run for each new/modified
+  entry after :meth:`~Reader.update_feeds()` call. Hooks will receive
+  :class:`Reader` instance, :class:`~types.Entry`-like object instance and
+  :class:`~types.EntryUpdateStatus` value
+
 
 Version 1.19
 ------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -61,6 +61,9 @@ Data objects
 .. autoclass:: UpdatedFeed
     :members:
 
+.. autoclass:: EntryUpdateStatus
+    :members:
+
 
 Exceptions
 ----------

--- a/src/reader/__init__.py
+++ b/src/reader/__init__.py
@@ -54,6 +54,7 @@ from .types import (
     EntrySearchCounts,
     UpdateResult,
     UpdatedFeed,
+    EntryUpdateStatus,
 )
 
 from .exceptions import (

--- a/src/reader/plugins/entry_dedupe.py
+++ b/src/reader/plugins/entry_dedupe.py
@@ -74,6 +74,8 @@ Entry user attributes are set as follows:
 import logging
 import re
 
+from reader.types import EntryUpdateStatus
+
 log = logging.getLogger('reader._plugins.feed_entry_dedupe')
 
 
@@ -111,7 +113,10 @@ def _is_duplicate(one, two):
     return same_title and same_text
 
 
-def _entry_dedupe_plugin(reader, entry):
+def _entry_dedupe_plugin(reader, entry, status):
+    if status is EntryUpdateStatus.MODIFIED:
+        return
+
     duplicates = [
         e
         for e in reader.get_entries(feed=entry.feed_url)
@@ -150,4 +155,4 @@ def _entry_dedupe_plugin(reader, entry):
 
 
 def init_reader(reader):
-    reader._post_entry_add_plugins.append(_entry_dedupe_plugin)
+    reader.after_entry_update_hooks.append(_entry_dedupe_plugin)

--- a/src/reader/plugins/mark_as_read.py
+++ b/src/reader/plugins/mark_as_read.py
@@ -29,6 +29,7 @@ import logging
 import re
 
 from reader.exceptions import MetadataNotFoundError
+from reader.types import EntryUpdateStatus
 
 # avoid circular imports
 
@@ -52,7 +53,10 @@ def _get_config(reader, feed_url, metadata_key, patterns_key):
     return []
 
 
-def _mark_as_read(reader, entry):
+def _mark_as_read(reader, entry, status):
+    if status is EntryUpdateStatus.MODIFIED:
+        return
+
     metadata_name = reader.make_reader_reserved_name('mark_as_read')
     patterns = _get_config(reader, entry.feed_url, metadata_name, 'title')
 
@@ -63,4 +67,4 @@ def _mark_as_read(reader, entry):
 
 
 def init_reader(reader):
-    reader._post_entry_add_plugins.append(_mark_as_read)
+    reader.after_entry_update_hooks.append(_mark_as_read)

--- a/src/reader/types.py
+++ b/src/reader/types.py
@@ -1,4 +1,5 @@
 import dataclasses
+import enum
 import re
 import traceback
 import warnings
@@ -478,6 +479,19 @@ class EntrySearchResult(_namedtuple_compat):
 
         """
         return self.feed_url, self.id
+
+
+class EntryUpdateStatus(enum.Enum):
+
+    """Data type representing status of entry.
+    Used by :py:attr:`~Reader.after_entry_update_hooks`.
+
+    .. versionadded:: 1.20
+
+    """
+
+    NEW = 'new'
+    MODIFIED = 'modified'
 
 
 # Semi-public API (typing support)

--- a/tests/test_plugins_entry_dedupe.py
+++ b/tests/test_plugins_entry_dedupe.py
@@ -92,6 +92,9 @@ def test_plugin(make_reader):
     important_one = parser.entry(
         1, 5, datetime(2010, 1, 1), title='important', summary='also important'
     )
+    modified_one = parser.entry(
+        1, 6, datetime(2010, 1, 1), title='title', summary='will be modified'
+    )
 
     # TODO just use the feeds/entries as arguments
 
@@ -109,6 +112,9 @@ def test_plugin(make_reader):
     )
     important_two = parser.entry(
         1, 15, datetime(2010, 1, 2), title='important', summary='also important'
+    )
+    modified_two = parser.entry(
+        1, 6, datetime(2010, 1, 1), title='title', summary='was modified'
     )
 
     reader.update_feeds()
@@ -128,6 +134,8 @@ def test_plugin(make_reader):
             # the old one is marked as read in favor of the new one
             (unread_one.id, True),
             (unread_two.id, False),
+            # modified entry is ignored by plugin
+            (modified_one.id, False),
         }
     } | {
         # the new one is important because the old one was;

--- a/tests/test_plugins_mark_as_read.py
+++ b/tests/test_plugins_mark_as_read.py
@@ -48,10 +48,14 @@ def test_regex_mark_as_read_bad_metadata(make_reader, value):
 
     one = parser.feed(1, datetime(2010, 1, 1))
     parser.entry(1, 1, datetime(2010, 1, 1), title='match')
+    parser.entry(1, 2, datetime(2010, 1, 1), title='will be modified')
 
     reader.add_feed(one)
     reader.set_feed_metadata_item(one, '.reader.mark_as_read', value)
 
     reader.update_feeds()
 
-    assert [e.read for e in reader.get_entries()] == [False]
+    parser.entry(1, 2, datetime(2010, 1, 1), title='modified')
+    reader.update_feeds()
+
+    assert [e.read for e in reader.get_entries()] == [False, False]

--- a/tests/test_reader_hooks.py
+++ b/tests/test_reader_hooks.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+
+from fakeparser import Parser
+
+from reader.types import EntryUpdateStatus
+
+
+def test_post_entry_update_hooks(reader):
+    parser = Parser()
+    reader._parser = parser
+
+    plugin_calls = []
+
+    def first_plugin(r, e, s):
+        assert r is reader
+        plugin_calls.append((first_plugin, e, s))
+
+    def second_plugin(r, e, s):
+        assert r is reader
+        plugin_calls.append((second_plugin, e, s))
+
+    feed = parser.feed(1, datetime(2010, 1, 1))
+    one = parser.entry(1, 1, datetime(2010, 1, 1))
+    reader.add_feed(feed.url)
+    reader.after_entry_update_hooks.append(first_plugin)
+    reader.update_feeds()
+    assert plugin_calls == [(first_plugin, one, EntryUpdateStatus.NEW)]
+    assert set(e.id for e in reader.get_entries()) == {'1, 1'}
+
+    plugin_calls[:] = []
+
+    feed = parser.feed(1, datetime(2010, 1, 2))
+    one = parser.entry(1, 1, datetime(2010, 1, 2))
+    two = parser.entry(1, 2, datetime(2010, 1, 2))
+    reader.after_entry_update_hooks.append(second_plugin)
+    reader.update_feeds()
+    assert plugin_calls == [
+        (first_plugin, two, EntryUpdateStatus.NEW),
+        (second_plugin, two, EntryUpdateStatus.NEW),
+        (first_plugin, one, EntryUpdateStatus.MODIFIED),
+        (second_plugin, one, EntryUpdateStatus.MODIFIED),
+    ]
+    assert set(e.id for e in reader.get_entries()) == {'1, 1', '1, 2'}
+
+    # TODO: What is the expected behavior if a plugin raises an exception?

--- a/tests/test_reader_private.py
+++ b/tests/test_reader_private.py
@@ -95,44 +95,6 @@ def test_update_parse(reader, call_update_method):
     assert parser.calls == [(feed.url, 'etag', 'last-modified')]
 
 
-def test_post_entry_add_plugins(reader):
-    parser = Parser()
-    reader._parser = parser
-
-    plugin_calls = []
-
-    def first_plugin(r, e):
-        assert r is reader
-        plugin_calls.append((first_plugin, e))
-
-    def second_plugin(r, e):
-        assert r is reader
-        plugin_calls.append((second_plugin, e))
-
-    feed = parser.feed(1, datetime(2010, 1, 1))
-    one = parser.entry(1, 1, datetime(2010, 1, 1))
-    reader.add_feed(feed.url)
-    reader._post_entry_add_plugins.append(first_plugin)
-    reader.update_feeds()
-    assert plugin_calls == [(first_plugin, one)]
-    assert set(e.id for e in reader.get_entries()) == {'1, 1'}
-
-    plugin_calls[:] = []
-
-    feed = parser.feed(1, datetime(2010, 1, 2))
-    one = parser.entry(1, 1, datetime(2010, 1, 2))
-    two = parser.entry(1, 2, datetime(2010, 1, 2))
-    reader._post_entry_add_plugins.append(second_plugin)
-    reader.update_feeds()
-    assert plugin_calls == [
-        (first_plugin, two),
-        (second_plugin, two),
-    ]
-    assert set(e.id for e in reader.get_entries()) == {'1, 1', '1, 2'}
-
-    # TODO: What is the expected behavior if a plugin raises an exception?
-
-
 def test_post_feed_update_plugins(reader):
     parser = Parser()
     reader._parser = parser


### PR DESCRIPTION
This PR fixes #241 by introducing new `after_entry_update_hooks` attribute to `Reader`. I tried following instructions from https://github.com/lemon24/reader/issues/241#issuecomment-859511918 , which were very helpful.

`./run.sh typing` is fine, but I needed to add some somewhat silly things to existing plugins tests for `./run.sh coverage-all` to pass.

Overall, I'm quite happy with current state, but I think documentation leaves few things to be desired.

First, generated documentation looks like that: [Screenshot_20210620_005538](https://user-images.githubusercontent.com/12373754/122657263-5780ef80-d162-11eb-944b-1ed171d59f94.png). For me, signature of content in list actually makes it harder to read. With all "important" and "new in" notices around, this is just too noisy. Also, I can't make `versionadded` to actually evaluate here. 

Second, I'm not sure it's easy to find documentation where it is now. I think part of the problem is that this is the first time we publicly talk about "hooks". So far, documentation only mentioned "plugins", which were documented quite extensively. It's not clear to me whether we want to gradually move from plugins to hooks (as hooks seem to require less code to utilize), should both concepts co-exist, or maybe preferred way is to create plugins that would register callbacks in pre-specified hooks containers.

Please let me know if there is anything you would like me to change before merge, I'll be happy to apply your suggestions.