### PR TITLE
Fix #281 Single entry without id and link fails entire feed

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -546,7 +546,36 @@ def test_missing_entry_id():
             """.strip(),
         )
     assert excinfo.value.url == 'url'
-    assert 'entry with no id' in excinfo.value.message
+    assert 'all entries with no id' in excinfo.value.message
+
+    # single malformed entry shouldn't fail entire feed
+    with pytest.warns(UserWarning) as warnings:
+        feed, entries = feedparser_parse(
+            'url',
+            """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <rss version="2.0">
+            <channel>
+                <item>
+                    <title>Example entry without id or link</title>
+                    <description>Here is some text.</description>
+                    <pubDate>Sun, 07 Sep 2009 16:20:00 +0000</pubDate>
+                </item>
+                <item>
+                    <link>http://www.example.com/blog/post/1</link>
+                    <title>Example entry</title>
+                    <description>Here is some text.</description>
+                    <pubDate>Sun, 06 Sep 2009 16:20:00 +0000</pubDate>
+                </item>
+            </channel>
+            </rss>
+            """.strip(),
+        )
+    assert len(entries) == 1
+    (warninfo,) = warnings
+    (warnmsg,) = warninfo.message.args
+    assert warnmsg.startswith('url')
+    assert 'entry with no id' in warnmsg
 
     # There is no fallback for Atom.
     with pytest.raises(ParseError) as excinfo:
@@ -565,7 +594,7 @@ def test_missing_entry_id():
             """.strip(),
         )
     assert excinfo.value.url == 'url'
-    assert 'entry with no id' in excinfo.value.message
+    assert 'all entries with no id' in excinfo.value.message
 
     # Same for JSON Feed.
     with pytest.raises(ParseError) as excinfo:


### PR DESCRIPTION
This fixes #281.

`ParseError` in `_feedparser_entry` is caught and re-emitted as warning. This way we salvage as much as we can from feeds that contain valid and invalid entries.

`_process_feedparser_dict` re-raises `ParseError` with slightly different message if all entries are invalid. This is to maintain interface compatibility with JSON Feed parser.

Reproducer:

Download [planetpython-buggy.xml.txt](https://github.com/lemon24/reader/files/8935715/planetpython-buggy.xml.txt) and run:

```
$ python -m reader --db db.sqlite --feed-root /tmp/ add --update 'file:planetpython-buggy.xml.txt' -vvvv
```

On master, this will raise exception; with this patch, it will emit warning `UserWarning: file:planetpython-buggy.xml.txt: entry with no id or link fallback`, but otherwise will work.

```
$ ./run.sh coverage-all
<snip>
TOTAL                                              10326    423   2963     90    95%

======================================== 1703 passed, 3 skipped, 3 xfailed, 18 warnings, 70 subtests passed in 30.91s =========================================
Wrote HTML report to htmlcov/index.html
Name    Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------
---------------------------------------------------
TOTAL    3396      0   1219      0   100%

22 files skipped due to complete coverage.
```

```
$ ./run.sh typing
Success: no issues found in 74 source files
```