### PR TITLE
Fix FutureWarning about _indent defined with functools.partial().

### DIFF
--- a/src/reader/_storage/_sql_utils.py
+++ b/src/reader/_storage/_sql_utils.py
@@ -196,7 +196,7 @@ class BaseQuery:
 
             yield '\n'
 
-    _indent = functools.partial(textwrap.indent, prefix='    ')
+    _indent = staticmethod(functools.partial(textwrap.indent, prefix='    '))
 
 
 if TYPE_CHECKING:  # pragma: no cover


### PR DESCRIPTION
FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in staticmethod() if you want to preserve the old behavior