### PR TITLE
Add --json option to list CLI commands

### DIFF
--- a/src/reader/_cli.py
+++ b/src/reader/_cli.py
@@ -406,6 +406,7 @@ def entries(reader, json_output):
     """List all the entries."""
     for entry in reader.get_entries():
         if json_output:
+            entry = entry._replace(_sequence=None)
             click.echo(json.dumps(entry, default=_json_default))
         else:
             click.echo(f"{entry.feed.url} {entry.link or entry.id}")

--- a/src/reader/_cli.py
+++ b/src/reader/_cli.py
@@ -385,7 +385,7 @@ def list_cmd():
     help='Output as JSON.',
 )
 @pass_reader
-def feeds(reader, json_output):
+def feeds(reader,json_output):
     """List all the feeds."""
     for feed in reader.get_feeds():
         if json_output:
@@ -402,7 +402,7 @@ def feeds(reader, json_output):
     help='Output as JSON.',
 )
 @pass_reader
-def entries(reader, json_output):
+def entries(reader,json_output):
     """List all the entries."""
     for entry in reader.get_entries():
         if json_output:

--- a/src/reader/_cli.py
+++ b/src/reader/_cli.py
@@ -7,8 +7,10 @@ from contextlib import nullcontext
 from datetime import datetime
 
 import click
+import json  #used to handle JSON in CLI 
 
 import reader
+from reader._hash_utils import _dataclass_dict
 
 from . import make_reader
 from . import StorageError
@@ -376,26 +378,33 @@ def list_cmd():
 
 
 @list_cmd.command()
+@click.option('--json','json_output',is_flag=True,help='output as json')
 @pass_reader
-def feeds(reader):
-    """List all the feeds."""
+def feeds(reader,json_output):
+    """List all the feeds"""
     for feed in reader.get_feeds():
-        click.echo(feed.url)
+        if json_output:
+            data=_dataclass_dict(feed)   #convert feed object into dictnary using dataclass_dict as suggested by moderator
+            click.echo(json.dumps(data,default=str))
+        else:
+            click.echo(feed.url)
 
 
 @list_cmd.command()
+@click.option('--json','json_output',is_flag=True,help='output as json')
 @pass_reader
-def entries(reader):
-    """List all the entries.
-
-    Outputs one line per entry in the following format:
-
-        <feed URL> <entry link or id>
-
-    """
+def entries(reader,json_output):
+    """List all the entries"""
     for entry in reader.get_entries():
-        click.echo(f"{entry.feed.url} {entry.link or entry.id}")
+        if json_output:
+            data = _dataclass_dict(entry)  #same idea as feeds,but for entries
+            
+            if "feed" in data:
+                data["feed"]=_dataclass_dict(entry.feed)     #feed was coming as string , to make it a JSON
 
+            click.echo(json.dumps(data,default=str))
+        else:
+            click.echo(f"{entry.feed.url} {entry.link or entry.id}")
 
 @cli.group()
 def search():

--- a/src/reader/_cli.py
+++ b/src/reader/_cli.py
@@ -7,10 +7,11 @@ from contextlib import nullcontext
 from datetime import datetime
 
 import click
-import json  #used to handle JSON in CLI 
+import json 
 
 import reader
-from reader._hash_utils import _dataclass_dict
+from reader._hash_utils import _json_default
+
 
 from . import make_reader
 from . import StorageError
@@ -376,33 +377,35 @@ def update(reader, url, new, scheduled, workers, verbose):
 def list_cmd():
     """List feeds or entries."""
 
-
 @list_cmd.command()
-@click.option('--json','json_output',is_flag=True,help='output as json')
+@click.option(
+    '--json',
+    'json_output',
+    is_flag=True,
+    help='Output as JSON.',
+)
 @pass_reader
-def feeds(reader,json_output):
-    """List all the feeds"""
+def feeds(reader, json_output):
+    """List all the feeds."""
     for feed in reader.get_feeds():
         if json_output:
-            data=_dataclass_dict(feed)   #convert feed object into dictnary using dataclass_dict as suggested by moderator
-            click.echo(json.dumps(data,default=str))
+            click.echo(json.dumps(feed, default=_json_default))
         else:
             click.echo(feed.url)
 
-
 @list_cmd.command()
-@click.option('--json','json_output',is_flag=True,help='output as json')
+@click.option(
+    '--json',
+    'json_output',
+    is_flag=True,
+    help='Output as JSON.',
+)
 @pass_reader
-def entries(reader,json_output):
-    """List all the entries"""
+def entries(reader, json_output):
+    """List all the entries."""
     for entry in reader.get_entries():
         if json_output:
-            data = _dataclass_dict(entry)  #same idea as feeds,but for entries
-            
-            if "feed" in data:
-                data["feed"]=_dataclass_dict(entry.feed)     #feed was coming as string , to make it a JSON
-
-            click.echo(json.dumps(data,default=str))
+            click.echo(json.dumps(entry, default=_json_default))
         else:
             click.echo(f"{entry.feed.url} {entry.link or entry.id}")
 

--- a/src/reader/_cli.py
+++ b/src/reader/_cli.py
@@ -385,7 +385,7 @@ def list_cmd():
     help='Output as JSON.',
 )
 @pass_reader
-def feeds(reader,json_output):
+def feeds(reader, json_output):
     """List all the feeds."""
     for feed in reader.get_feeds():
         if json_output:
@@ -402,7 +402,7 @@ def feeds(reader,json_output):
     help='Output as JSON.',
 )
 @pass_reader
-def entries(reader,json_output):
+def entries(reader, json_output):
     """List all the entries."""
     for entry in reader.get_entries():
         if json_output:

--- a/src/reader/_cli.py
+++ b/src/reader/_cli.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import logging
 import os.path
 import shutil
@@ -7,11 +8,9 @@ from contextlib import nullcontext
 from datetime import datetime
 
 import click
-import json 
 
 import reader
 from reader._hash_utils import _json_default
-
 
 from . import make_reader
 from . import StorageError
@@ -377,6 +376,7 @@ def update(reader, url, new, scheduled, workers, verbose):
 def list_cmd():
     """List feeds or entries."""
 
+
 @list_cmd.command()
 @click.option(
     '--json',
@@ -393,6 +393,7 @@ def feeds(reader, json_output):
         else:
             click.echo(feed.url)
 
+
 @list_cmd.command()
 @click.option(
     '--json',
@@ -408,6 +409,7 @@ def entries(reader, json_output):
             click.echo(json.dumps(entry, default=_json_default))
         else:
             click.echo(f"{entry.feed.url} {entry.link or entry.id}")
+
 
 @cli.group()
 def search():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json as _json
 import logging
 import os
 import pathlib
@@ -6,7 +7,6 @@ from datetime import timedelta
 import click
 import pytest
 import yaml
-import json as _json
 from click.testing import CliRunner
 
 from reader import PluginError
@@ -123,15 +123,12 @@ def test_cli(db_path, data_dir, monkeypatch):
     assert len(feeds) == 1
     assert feeds[0]['url'] == feed_path
 
-    
-
-    
     result = invoke('list', 'entries', '--json')
     assert result.exit_code == 0
     entries_data = list(map(_json.loads, result.output.splitlines()))
-    assert {(item['feed']['url'], item['link'] or item['id']) for item in entries_data} == {
-    (feed_path, e.link or e.id) for e in expected['entries']
-    }
+    assert {
+        (item['feed']['url'], item['link'] or item['id']) for item in entries_data
+    } == {(feed_path, e.link or e.id) for e in expected['entries']}
 
     result = invoke('search', 'status')
     assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,7 +128,7 @@ def test_cli(db_path, data_dir, monkeypatch):
     assert feed_data['url'] == feed_path
 
     # test JSON output for entries
-    result = invoke('list', 'entries', '--json')
+    result = invoke('list','entries','--json')
     assert result.exit_code == 0
     lines = result.output.strip().splitlines()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,10 +115,8 @@ def test_cli(db_path, data_dir, monkeypatch):
     assert {tuple(l.split()) for l in result.output.splitlines()} == {
         (feed_path, e.link or e.id) for e in expected['entries']
     }
-    
-    
 
-# test JSON output for feeds
+    # test JSON output for feeds
     result = invoke('list', 'feeds', '--json')
     assert result.exit_code == 0
     lines = result.output.strip().splitlines()
@@ -128,7 +126,6 @@ def test_cli(db_path, data_dir, monkeypatch):
     assert len(lines) == 1
     feed_data = _json.loads(lines[0])
     assert feed_data['url'] == feed_path
-
 
     # test JSON output for entries
     result = invoke('list', 'entries', '--json')
@@ -142,8 +139,6 @@ def test_cli(db_path, data_dir, monkeypatch):
     for item in entries_data:
         assert 'id' in item
         assert 'feed' in item
-    
-
 
     result = invoke('search', 'status')
     assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,7 +66,7 @@ def test_cli(db_path, data_dir, monkeypatch):
     expected = {'url_base': url_base, 'rel_base': rel_base}
     exec(data_dir.joinpath(feed_filename + '.py').read_text(), expected)
 
-    runner = CliRunner(catch_exceptions=False)
+    runner = CliRunner()  # remove deprecated catch_exceptions argument
 
     def invoke(*args):
         return runner.invoke(cli, ('--db', db_path, '--feed-root', '') + args)
@@ -115,6 +115,35 @@ def test_cli(db_path, data_dir, monkeypatch):
     assert {tuple(l.split()) for l in result.output.splitlines()} == {
         (feed_path, e.link or e.id) for e in expected['entries']
     }
+    
+    
+
+# test JSON output for feeds
+    result = invoke('list', 'feeds', '--json')
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+
+    import json as _json
+
+    assert len(lines) == 1
+    feed_data = _json.loads(lines[0])
+    assert feed_data['url'] == feed_path
+
+
+    # test JSON output for entries
+    result = invoke('list', 'entries', '--json')
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+
+    assert len(lines) == len(expected['entries'])
+
+    entries_data = [_json.loads(line) for line in lines]
+
+    for item in entries_data:
+        assert 'id' in item
+        assert 'feed' in item
+    
+
 
     result = invoke('search', 'status')
     assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,7 +128,7 @@ def test_cli(db_path, data_dir, monkeypatch):
     assert feed_data['url'] == feed_path
 
     # test JSON output for entries
-    result = invoke('list','entries','--json')
+    result = invoke('list', 'entries', '--json')
     assert result.exit_code == 0
     lines = result.output.strip().splitlines()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 import click
 import pytest
 import yaml
+import json as _json
 from click.testing import CliRunner
 
 from reader import PluginError
@@ -116,29 +117,21 @@ def test_cli(db_path, data_dir, monkeypatch):
         (feed_path, e.link or e.id) for e in expected['entries']
     }
 
-    # test JSON output for feeds
     result = invoke('list', 'feeds', '--json')
     assert result.exit_code == 0
-    lines = result.output.strip().splitlines()
+    feeds = list(map(_json.loads, result.output.splitlines()))
+    assert len(feeds) == 1
+    assert feeds[0]['url'] == feed_path
 
-    import json as _json
+    
 
-    assert len(lines) == 1
-    feed_data = _json.loads(lines[0])
-    assert feed_data['url'] == feed_path
-
-    # test JSON output for entries
+    
     result = invoke('list', 'entries', '--json')
     assert result.exit_code == 0
-    lines = result.output.strip().splitlines()
-
-    assert len(lines) == len(expected['entries'])
-
-    entries_data = [_json.loads(line) for line in lines]
-
-    for item in entries_data:
-        assert 'id' in item
-        assert 'feed' in item
+    entries_data = list(map(_json.loads, result.output.splitlines()))
+    assert {(item['feed']['url'], item['link'] or item['id']) for item in entries_data} == {
+    (feed_path, e.link or e.id) for e in expected['entries']
+    }
 
     result = invoke('search', 'status')
     assert result.exit_code == 0
@@ -198,7 +191,7 @@ def raise_exception_plugin(thing):
 def test_cli_plugin(db_path, monkeypatch, tests_dir):
     monkeypatch.syspath_prepend(tests_dir)
 
-    runner = CliRunner()
+    runner = CliRunner(catch_exceptions=False)
 
     with pytest.raises(PluginError):
         result = runner.invoke(


### PR DESCRIPTION
Adds a --json flag to the `list feeds` and `list entries` CLI commands.

When used, output is emitted as JSON Lines (one JSON object per line), making it easier to use in scripts and pipelines.

Implementation details:
- Uses `_json_default` for serialization (handles dataclasses and datetime)
- Outputs JSON Lines (one object per line, not an array)
- Keeps existing plain-text output unchanged

Tests:
- Added tests for `--json` output
- Updated tests to remove deprecated `catch_exceptions` argument from `CliRunner`

Example usage:

    python -m reader list feeds --json
    python -m reader list entries --json