### PR TITLE
removed iso8601 dependency from the json date feed parser and replace…

### DIFF
--- a/src/reader/_parser/jsonfeed.py
+++ b/src/reader/_parser/jsonfeed.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
-import iso8601
-
 from .._types import EntryData
 from .._types import FeedData
 from ..exceptions import ParseError
@@ -183,8 +181,9 @@ def _process_entry(feed_url: str, d: Any, feed_lang: str | None) -> EntryData:
 
 def _parse_date(s: str) -> datetime | None:
     try:
-        dt = iso8601.parse_date(s)
-    except iso8601.ParseError:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
         return None
-    assert isinstance(dt, datetime)
+    if dt.tzinfo is None:  # pragma: no cover
+        dt = dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -113,7 +113,7 @@ def test_cli(db_path, data_dir, monkeypatch):
 
     result = invoke('list', 'entries')
     assert result.exit_code == 0
-    assert {tuple(l.split()) for l in result.output.splitlines()} == {
+    assert {tuple(l.rsplit(None, 1)) for l in result.output.splitlines()} == {
         (feed_path, e.link or e.id) for e in expected['entries']
     }
 
@@ -152,7 +152,7 @@ def test_cli(db_path, data_dir, monkeypatch):
 
     result = invoke('search', 'entries', 'amok')
     assert result.exit_code == 0
-    assert {tuple(l.split()) for l in result.output.splitlines()} == {
+    assert {tuple(l.rsplit(None, 1)) for l in result.output.splitlines()} == {
         (feed_path, e.link or e.id)
         for e in expected['entries']
         if e.title and 'amok' in e.title.lower()
@@ -160,7 +160,7 @@ def test_cli(db_path, data_dir, monkeypatch):
 
     result = invoke('search', 'entries', 'again')
     assert result.exit_code == 0
-    assert {tuple(l.split()) for l in result.output.splitlines()} == {
+    assert {tuple(l.rsplit(None, 1)) for l in result.output.splitlines()} == {
         (feed_path, e.link or e.id)
         for e in expected['entries']
         if e.title and 'again' in e.title.lower()
@@ -168,7 +168,7 @@ def test_cli(db_path, data_dir, monkeypatch):
 
     result = invoke('search', 'entries', 'nope')
     assert result.exit_code == 0
-    assert {tuple(l.split()) for l in result.output.splitlines()} == set()
+    assert {tuple(l.rsplit(None, 1)) for l in result.output.splitlines()} == set()
 
     result = invoke('search', 'disable')
     assert result.exit_code == 0


### PR DESCRIPTION
removed iso8601 dependency from the json date feed parser and replaced with datetime.fromisoformat(). Also updated 4 asserts within test_cli that was not allowing whitespaces within project folder paths by replacing split() with rsplit(None,1) to split at the last whitespace.