### PR TITLE
Add make_reader(migrate=False) and matching CLI option 

### DIFF
--- a/src/reader/_cli.py
+++ b/src/reader/_cli.py
@@ -170,6 +170,11 @@ class MapParamType(click.ParamType):
 )
 @click.option('--read-only/--no-read-only', help="Do not modify storage.")
 @click.option(
+    '--migrate/--no-migrate',
+    default=True,
+    help="Enable or disable automatic schema migrations (default: enabled).",
+)
+@click.option(
     '--plugin',
     'plugins',
     show_envvar=True,
@@ -202,7 +207,9 @@ class MapParamType(click.ParamType):
 )
 @click.version_option(reader.__version__, message='%(prog)s %(version)s')
 @click.pass_context
-def cli(ctx, url, feed_root, read_only, plugins, cli_plugins, reserved_name_scheme):
+def cli(
+    ctx, url, feed_root, read_only, migrate, plugins, cli_plugins, reserved_name_scheme
+):
     """reader command-line interface.
 
     Option defaults can be set via environment variables;

--- a/src/reader/_storage/__init__.py
+++ b/src/reader/_storage/__init__.py
@@ -27,9 +27,13 @@ class Storage(FeedsMixin, EntriesMixin, TagsMixin, StorageBase):
     """
 
     def __init__(
-        self, path: str, read_only: bool = False, timeout: float | None = None
+        self,
+        path: str,
+        read_only: bool = False,
+        timeout: float | None = None,
+        migrate: bool = True,
     ):
-        super().__init__(path, read_only, timeout)
+        super().__init__(path, read_only, timeout, migrate)
         self.changes: ChangeTrackerType = Changes(self)
 
     def make_search(self) -> SearchType:

--- a/src/reader/_storage/__init__.py
+++ b/src/reader/_storage/__init__.py
@@ -30,10 +30,10 @@ class Storage(FeedsMixin, EntriesMixin, TagsMixin, StorageBase):
         self,
         path: str,
         read_only: bool = False,
-        timeout: float | None = None,
         migrate: bool = True,
+        timeout: float | None = None,
     ):
-        super().__init__(path, read_only, timeout, migrate)
+        super().__init__(path, read_only, migrate, timeout)
         self.changes: ChangeTrackerType = Changes(self)
 
     def make_search(self) -> SearchType:

--- a/src/reader/_storage/_base.py
+++ b/src/reader/_storage/_base.py
@@ -7,6 +7,7 @@ import sqlite3
 import sys
 from collections.abc import Callable
 from collections.abc import Iterable
+from dataclasses import replace
 from functools import partial
 from typing import Any
 from typing import Self
@@ -52,7 +53,13 @@ class StorageBase:
     chunk_size = 2**8
 
     @wrap_exceptions(message="while opening database")
-    def __init__(self, path: str, read_only: bool, timeout: float | None = None):
+    def __init__(
+        self,
+        path: str,
+        read_only: bool,
+        timeout: float | None = None,
+        migrate: bool = True,
+    ):
         kwargs: dict[str, Any] = {'factory': CONNECTION_CLS}
         if timeout is not None:
             kwargs['timeout'] = timeout
@@ -61,23 +68,33 @@ class StorageBase:
         # has to run for every connection (in every thread),
         # since it's not persisted across connections
         self.factory = _sqlite_utils.LocalConnectionFactory(
-            path, self.setup_db, read_only, **kwargs
+            path, partial(self.setup_db, migrate=migrate), read_only, **kwargs
         )
 
     def get_db(self) -> sqlite3.Connection:
         return self.factory()
 
     @staticmethod
-    def setup_db(db: sqlite3.Connection) -> None:
+    def setup_db(db: sqlite3.Connection, migrate: bool = True) -> None:
         # Private API, used by tests.
-
         from . import MINIMUM_SQLITE_VERSION
         from . import REQUIRED_SQLITE_FUNCTIONS
         from ._schema import MIGRATION
 
+        migration = MIGRATION
+        if not migrate:
+            migration = replace(
+                MIGRATION,
+                migrations={},
+                missing_suffix=(
+                    "; reader created with migrate=False, "
+                    "so migrations cannot run automatically;"
+                    " pass migrate=True to allow it"
+                ),
+            )
         return _sqlite_utils.setup_db(
             db,
-            migration=MIGRATION,
+            migration=migration,
             id=APPLICATION_ID,
             minimum_sqlite_version=MINIMUM_SQLITE_VERSION,
             required_sqlite_functions=REQUIRED_SQLITE_FUNCTIONS,

--- a/src/reader/_storage/_base.py
+++ b/src/reader/_storage/_base.py
@@ -57,8 +57,8 @@ class StorageBase:
         self,
         path: str,
         read_only: bool,
-        timeout: float | None = None,
         migrate: bool = True,
+        timeout: float | None = None,
     ):
         kwargs: dict[str, Any] = {'factory': CONNECTION_CLS}
         if timeout is not None:

--- a/src/reader/core.py
+++ b/src/reader/core.py
@@ -101,6 +101,7 @@ def make_reader(
     *,
     feed_root: str | None = None,
     read_only: bool = False,
+    migrate: bool = True,
     plugins: Iterable[PluginInput[Reader]] = DEFAULT_PLUGINS,
     session_timeout: TimeoutType = DEFAULT_TIMEOUT,
     reserved_name_scheme: Mapping[str, str] = DEFAULT_RESERVED_NAME_SCHEME,
@@ -166,6 +167,11 @@ def make_reader(
 
         read_only (bool):
             Allow only read storage operations.
+
+        migrate (bool):
+            Allow storage to migrate to a newer version automatically,
+            if needed. If :const:`False` and a migration is needed,
+            :exc:`StorageError` is raised.
 
         plugins (iterable(str or callable(Reader)) or None):
             An iterable of built-in plugin names (``.<plugin>``),
@@ -247,6 +253,9 @@ def make_reader(
         Built-in plugins starting with ``reader.``;
         use ``.<plugin>`` instead.
 
+    .. versionadded:: 3.27
+        The ``migrate`` keyword argument.
+
     """
 
     # Do as much work as possible before creating the storage.
@@ -272,7 +281,9 @@ def make_reader(
     # See this comment for details on how it should evolve:
     # https://github.com/lemon24/reader/issues/168#issuecomment-642002049
 
-    storage: StorageType = _storage or Storage(url, read_only=read_only)
+    storage: StorageType = _storage or Storage(
+        url, read_only=read_only, migrate=migrate
+    )
 
     try:
         # For now, we're using a storage-bound search provider.

--- a/tests/test_reader_lifecycle.py
+++ b/tests/test_reader_lifecycle.py
@@ -10,6 +10,7 @@ but until we have a different implementation it's simpler this way
 import asyncio
 import concurrent.futures
 import functools
+import pathlib
 import sqlite3
 import sys
 import threading
@@ -19,6 +20,7 @@ import pytest
 
 from reader import SearchError
 from reader import StorageError
+from reader._storage._sqlite_utils import HeavyMigration
 from utils import rename_argument
 
 pytestmark = pytest.mark.noscheduled
@@ -385,3 +387,34 @@ def test_paths_read_only_private(make_reader, path):
     # can open, but can't create tables etc. because read only
     with pytest.raises(StorageError):
         make_reader(path, read_only=True)
+
+
+def test_migrate(make_reader, db_path, monkeypatch):
+    # By default, migrations should happen automatically.
+    reader = make_reader(db_path)
+    reader.close()
+
+    # Build a database stuck at version 1
+    old_db_path = str(pathlib.Path(db_path).parent / 'old.sqlite')
+    db = sqlite3.connect(old_db_path)
+    try:
+        HeavyMigration(create=lambda db: None, version=1, migrations={}).migrate(db)
+    finally:
+        db.close()
+
+    # Define a new schema (version 2) with trivial migrations from version 1 to 2
+    new_migration = HeavyMigration(
+        create=lambda db: None,
+        version=2,
+        migrations={1: lambda db: None},
+    )
+    monkeypatch.setattr('reader._storage._schema.MIGRATION', new_migration)
+
+    # migrate=False, refuse and raise StorageError.
+    with pytest.raises(StorageError) as excinfo:
+        make_reader(old_db_path, migrate=False)
+    assert 'migrate=False' in str(excinfo.value)
+
+    # migrate=True (the default), migrate successfully.
+    reader = make_reader(old_db_path, migrate=True)
+    reader.close()

--- a/tests/test_reader_lifecycle.py
+++ b/tests/test_reader_lifecycle.py
@@ -390,31 +390,26 @@ def test_paths_read_only_private(make_reader, path):
 
 
 def test_migrate(make_reader, db_path, monkeypatch):
-    # By default, migrations should happen automatically.
-    reader = make_reader(db_path)
-    reader.close()
-
-    # Build a database stuck at version 1
-    old_db_path = str(pathlib.Path(db_path).parent / 'old.sqlite')
-    db = sqlite3.connect(old_db_path)
-    try:
-        HeavyMigration(create=lambda db: None, version=1, migrations={}).migrate(db)
-    finally:
-        db.close()
-
-    # Define a new schema (version 2) with trivial migrations from version 1 to 2
-    new_migration = HeavyMigration(
+    migration = HeavyMigration(
         create=lambda db: None,
-        version=2,
-        migrations={1: lambda db: None},
+        version=1,
+        migrations={},
     )
-    monkeypatch.setattr('reader._storage._schema.MIGRATION', new_migration)
+    monkeypatch.setattr('reader._storage._schema.MIGRATION', migration)
 
-    # migrate=False, refuse and raise StorageError.
+    # Test empty case
+    with make_reader(db_path) as reader:
+        assert migration.get_version(reader._storage.get_db()) == 1
+
+    # Update migration definition to version 2
+    migration.version = 2
+    migration.migrations[1] = lambda _: None
+
+    # Test make_reader(db_path, migrate=False)
     with pytest.raises(StorageError) as excinfo:
-        make_reader(old_db_path, migrate=False)
+        make_reader(db_path, migrate=False)
     assert 'migrate=False' in str(excinfo.value)
 
-    # migrate=True (the default), migrate successfully.
-    reader = make_reader(old_db_path, migrate=True)
-    reader.close()
+    # Test make_reader(db_path)
+    with make_reader(db_path) as reader:
+        assert migration.get_version(reader._storage.get_db()) == 2


### PR DESCRIPTION
Fixes #403 

Adds a `migrate` flag to `make_reader()` (default `True`) and a matching `--migrate/--no-migrate` CLI flag.When
`migrate=False` and a migration is needed, `StorageError` is raised instead of migrating, done by passing `setup_db()` a copy of `MIGRATION` with an empty `migrations` dict and a custom `missing_suffix`, as suggested in the issue.

**Changes :**
- `_storage/_base.py`: `StorageBase.setup_db()` accepts `migrate`; builds
  an empty-migrations copy of `MIGRATION` with a custom error suffix
  when `migrate=False`.
- `_storage/__init__.py`: `Storage.__init__` threads `migrate` through.
- `core.py`: `make_reader()` gains the `migrate` parameter + docstring.
- `_cli.py`: adds `--migrate/--no-migrate` (default `True`).
- `tests/test_reader_lifecycle.py`: new `test_migrate`, verifying
  `StorageError` is raised when `migrate=False` and a migration is
  needed, and that `migrate=True` still migrates normally.

**Verification**
Ran the full test suite, coverage, mypy strict, and the docs build all passing locally.